### PR TITLE
fix: change starts with string

### DIFF
--- a/src/StandSupportTool/ProfileManager.cs
+++ b/src/StandSupportTool/ProfileManager.cs
@@ -28,7 +28,7 @@ namespace StandSupportTool
                     var lines = File.ReadAllLines(metaStateFilePath);
                     foreach (var line in lines)
                     {
-                        if (line.StartsWith("Active Profile:"))
+                        if (line.StartsWith("Load On Inject:"))
                         {
                             return line.Split(':')[1].Trim();
                         }


### PR DESCRIPTION
In the file `src/StandSupportTool/ProfileManager.cs` we had `"Active Profile"` in the `line.StartsWith()` and Stand now uses `"Load On Inject"`, so I just changed that. :D