### PR TITLE
Download on desktop

### DIFF
--- a/src/.config/dotnet-tools.json
+++ b/src/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "csharpier": {
+      "version": "0.29.2",
+      "commands": [
+        "dotnet-csharpier"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/src/StandSupportTool/ActivationKey.xaml.cs
+++ b/src/StandSupportTool/ActivationKey.xaml.cs
@@ -19,7 +19,12 @@ namespace StandSupportTool
 
             if (!activationKey.Contains(validPattern))
             {
-                MessageBox.Show("The key you are trying to use doesn't follow the correct pattern, it must contain \"Stand-Activate-\".", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    "The key you are trying to use doesn't follow the correct pattern, it must contain \"Stand-Activate-\".",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
                 return;
             }
 
@@ -29,7 +34,12 @@ namespace StandSupportTool
             // This will work as long as keys don't contain uppercase characters
             if (!keySuffix.All(c => char.IsLower(c) || char.IsDigit(c)))
             {
-                MessageBox.Show("This is not an activation key, it contains uppercase characters.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    "This is not an activation key, it contains uppercase characters.",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
                 return;
             }
 

--- a/src/StandSupportTool/ActivationManager.cs
+++ b/src/StandSupportTool/ActivationManager.cs
@@ -11,7 +11,9 @@ namespace StandSupportTool
         public ActivationManager()
         {
             // Initialize the path to the activation key file
-            string appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            string appDataPath = Environment.GetFolderPath(
+                Environment.SpecialFolder.ApplicationData
+            );
             string standDir = Path.Combine(appDataPath, "Stand");
             activationKeyFilePath = Path.Combine(standDir, "Activation Key.txt");
         }
@@ -27,13 +29,23 @@ namespace StandSupportTool
                 }
                 else
                 {
-                    MessageBox.Show("Activation Key file does not exist.", "Info", MessageBoxButton.OK, MessageBoxImage.Information);
+                    MessageBox.Show(
+                        "Activation Key file does not exist.",
+                        "Info",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Information
+                    );
                     return string.Empty;
                 }
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Failed to read activation key: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Failed to read activation key: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
                 return string.Empty;
             }
         }
@@ -43,7 +55,10 @@ namespace StandSupportTool
         {
             try
             {
-                string standDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Stand");
+                string standDir = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                    "Stand"
+                );
 
                 // Create directory if it doesn't exist
                 if (!Directory.Exists(standDir))
@@ -55,12 +70,22 @@ namespace StandSupportTool
                 File.WriteAllText(activationKeyFilePath, activationKey);
 
                 // Show success message
-                MessageBox.Show("Activation key saved successfully.", "Success", MessageBoxButton.OK, MessageBoxImage.Information);
+                MessageBox.Show(
+                    "Activation key saved successfully.",
+                    "Success",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information
+                );
             }
             catch (Exception ex)
             {
                 // Show error message
-                MessageBox.Show($"Failed to write activation key: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Failed to write activation key: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
         }
 

--- a/src/StandSupportTool/AntivirusInfo.cs
+++ b/src/StandSupportTool/AntivirusInfo.cs
@@ -16,42 +16,58 @@ namespace StandSupportTool
             try
             {
                 // Annoying but avoids random AVs flagging the exe
-                string securityCenter64 = "XHJvb3RcU2VjdXJpdHlDZW50ZXIy";       // @"\root\SecurityCenter2"
-                string query64 = "U0VMRUNUICogRlJPTSBBbnRpdmlydXNQcm9kdWN0";    //  "SELECT * FROM AntivirusProduct"
+                string securityCenter64 = "XHJvb3RcU2VjdXJpdHlDZW50ZXIy"; // @"\root\SecurityCenter2"
+                string query64 = "U0VMRUNUICogRlJPTSBBbnRpdmlydXNQcm9kdWN0"; //  "SELECT * FROM AntivirusProduct"
 
-                string wmipathstr = @"\\" + Environment.MachineName + Base64.Decode(securityCenter64);
+                string wmipathstr =
+                    @"\\" + Environment.MachineName + Base64.Decode(securityCenter64);
                 string query = Base64.Decode(query64);
 
-                using (ManagementObjectSearcher searcher = new ManagementObjectSearcher(wmipathstr, query))
+                using (
+                    ManagementObjectSearcher searcher = new ManagementObjectSearcher(
+                        wmipathstr,
+                        query
+                    )
+                )
                 using (ManagementObjectCollection instances = searcher.Get())
                 {
                     foreach (ManagementObject instance in instances)
                     {
                         string displayName = instance["displayName"]?.ToString() ?? "Unknown";
-                        string exePath = instance["pathToSignedReportingExe"]?.ToString() ?? "Unknown";
+                        string exePath =
+                            instance["pathToSignedReportingExe"]?.ToString() ?? "Unknown";
 
-                        antivirusInfos.Add(new AntivirusInfo
-                        {
-                            DisplayName = displayName,
-                            ExePath = exePath
-                        });
+                        antivirusInfos.Add(
+                            new AntivirusInfo { DisplayName = displayName, ExePath = exePath }
+                        );
                     }
                 }
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Failed to gather antivirus information: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Failed to gather antivirus information: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
 
             return antivirusInfos;
         }
+
         public bool IsDefenderInstalled()
         {
             List<AntivirusInfo> antivirusInfos = GetAntivirusInfo();
             foreach (var antivirus in antivirusInfos)
             {
-                if (antivirus.DisplayName.Contains("Defender", StringComparison.OrdinalIgnoreCase) ||
-                    antivirus.DisplayName.Contains("Windows Defender", StringComparison.OrdinalIgnoreCase))
+                if (
+                    antivirus.DisplayName.Contains("Defender", StringComparison.OrdinalIgnoreCase)
+                    || antivirus.DisplayName.Contains(
+                        "Windows Defender",
+                        StringComparison.OrdinalIgnoreCase
+                    )
+                )
                 {
                     return true;
                 }
@@ -64,8 +80,13 @@ namespace StandSupportTool
             List<AntivirusInfo> antivirusInfos = GetAntivirusInfo();
             foreach (var antivirus in antivirusInfos)
             {
-                if (!antivirus.DisplayName.Contains("Defender", StringComparison.OrdinalIgnoreCase) &&
-                    !antivirus.DisplayName.Contains("Windows Defender", StringComparison.OrdinalIgnoreCase))
+                if (
+                    !antivirus.DisplayName.Contains("Defender", StringComparison.OrdinalIgnoreCase)
+                    && !antivirus.DisplayName.Contains(
+                        "Windows Defender",
+                        StringComparison.OrdinalIgnoreCase
+                    )
+                )
                 {
                     return true;
                 }

--- a/src/StandSupportTool/App.xaml.cs
+++ b/src/StandSupportTool/App.xaml.cs
@@ -23,7 +23,12 @@ namespace StandSupportTool
                         }
                         else
                         {
-                            MessageBox.Show("Invalid arguments for adding exclusion.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                            MessageBox.Show(
+                                "Invalid arguments for adding exclusion.",
+                                "Error",
+                                MessageBoxButton.OK,
+                                MessageBoxImage.Error
+                            );
                             Environment.Exit(1);
                         }
                         break;
@@ -34,7 +39,12 @@ namespace StandSupportTool
                     //     break;
 
                     default:
-                        MessageBox.Show("Unknown command.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                        MessageBox.Show(
+                            "Unknown command.",
+                            "Error",
+                            MessageBoxButton.OK,
+                            MessageBoxImage.Error
+                        );
                         Environment.Exit(1);
                         break;
                 }

--- a/src/StandSupportTool/AssemblyInfo.cs
+++ b/src/StandSupportTool/AssemblyInfo.cs
@@ -1,10 +1,10 @@
 using System.Windows;
 
 [assembly: ThemeInfo(
-    ResourceDictionaryLocation.None,            //where theme specific resource dictionaries are located
-                                                //(used if a resource is not found in the page,
-                                                // or application resource dictionaries)
-    ResourceDictionaryLocation.SourceAssembly   //where the generic resource dictionary is located
-                                                //(used if a resource is not found in the page,
-                                                // app, or any theme specific resource dictionaries)
+    ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
+    //(used if a resource is not found in the page,
+    // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly //where the generic resource dictionary is located
+//(used if a resource is not found in the page,
+// app, or any theme specific resource dictionaries)
 )]

--- a/src/StandSupportTool/AvChecker.xaml.cs
+++ b/src/StandSupportTool/AvChecker.xaml.cs
@@ -8,8 +8,8 @@ namespace StandSupportTool
 {
     public partial class AvChecker : BaseWindow
     {
-
         static AntivirusInfo antivirusInfo = new AntivirusInfo();
+
         public AvChecker()
         {
             InitializeComponent();
@@ -29,16 +29,26 @@ namespace StandSupportTool
                 // We must expand the EV since AVs like Defender have that in their PATH
                 string expandedPath = Environment.ExpandEnvironmentVariables(exePath);
 
-                if (expandedPath.Contains("MsMpeng.exe"))   // This is Michaelsoft Defender, we must run it differently!
+                if (expandedPath.Contains("MsMpeng.exe")) // This is Michaelsoft Defender, we must run it differently!
                 {
                     try
                     {
-                        Process.Start(new ProcessStartInfo("windowsdefender://threat") { UseShellExecute = true });
+                        Process.Start(
+                            new ProcessStartInfo("windowsdefender://threat")
+                            {
+                                UseShellExecute = true,
+                            }
+                        );
                         return;
                     }
                     catch (Exception ex)
                     {
-                        MessageBox.Show($"Failed to start Windows Defender: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                        MessageBox.Show(
+                            $"Failed to start Windows Defender: {ex.Message}",
+                            "Error",
+                            MessageBoxButton.OK,
+                            MessageBoxImage.Error
+                        );
                     }
                 }
 
@@ -49,7 +59,12 @@ namespace StandSupportTool
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show($"Failed to start process: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show(
+                        $"Failed to start process: {ex.Message}",
+                        "Error",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Error
+                    );
                 }
             }
         }

--- a/src/StandSupportTool/Base64.cs
+++ b/src/StandSupportTool/Base64.cs
@@ -12,7 +12,10 @@ namespace StandSupportTool
         {
             if (string.IsNullOrEmpty(input))
             {
-                throw new ArgumentException("The input string cannot be null or empty.", nameof(input));
+                throw new ArgumentException(
+                    "The input string cannot be null or empty.",
+                    nameof(input)
+                );
             }
 
             try
@@ -22,7 +25,10 @@ namespace StandSupportTool
             }
             catch (Exception ex)
             {
-                throw new InvalidOperationException("An error occurred during Base64 encoding.", ex);
+                throw new InvalidOperationException(
+                    "An error occurred during Base64 encoding.",
+                    ex
+                );
             }
         }
 
@@ -30,7 +36,10 @@ namespace StandSupportTool
         {
             if (string.IsNullOrEmpty(base64string))
             {
-                throw new ArgumentException("The input string cannot be null or empty.", nameof(base64string));
+                throw new ArgumentException(
+                    "The input string cannot be null or empty.",
+                    nameof(base64string)
+                );
             }
 
             try
@@ -44,7 +53,10 @@ namespace StandSupportTool
             }
             catch (Exception ex)
             {
-                throw new InvalidOperationException("An error occurred during Base64 decoding.", ex);
+                throw new InvalidOperationException(
+                    "An error occurred during Base64 decoding.",
+                    ex
+                );
             }
         }
     }

--- a/src/StandSupportTool/BaseWindow.cs
+++ b/src/StandSupportTool/BaseWindow.cs
@@ -29,7 +29,12 @@ namespace StandSupportTool
                 throw new InvalidOperationException("The window handle is not initialized.");
             }
 
-            int result = DwmSetWindowAttribute(windowHandle, attribute, ref useImmersiveDarkMode, Marshal.SizeOf(typeof(bool)));
+            int result = DwmSetWindowAttribute(
+                windowHandle,
+                attribute,
+                ref useImmersiveDarkMode,
+                Marshal.SizeOf(typeof(bool))
+            );
 
             if (result != 0)
             {
@@ -38,11 +43,16 @@ namespace StandSupportTool
         }
 
         [DllImport("dwmapi.dll", PreserveSig = true)]
-        private static extern int DwmSetWindowAttribute(IntPtr hwnd, DWMWINDOWATTRIBUTE dwAttribute, ref bool pvAttribute, int cbAttribute);
+        private static extern int DwmSetWindowAttribute(
+            IntPtr hwnd,
+            DWMWINDOWATTRIBUTE dwAttribute,
+            ref bool pvAttribute,
+            int cbAttribute
+        );
 
         private enum DWMWINDOWATTRIBUTE
         {
-            DWMWA_USE_IMMERSIVE_DARK_MODE = 20
+            DWMWA_USE_IMMERSIVE_DARK_MODE = 20,
         }
     }
 }

--- a/src/StandSupportTool/CacheManager.cs
+++ b/src/StandSupportTool/CacheManager.cs
@@ -8,10 +8,22 @@ namespace StandSupportTool
     public class CacheManager
     {
         // Define cache directory paths
-        private static readonly string StandCacheDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Stand/Cache");
-        private static readonly string StandBinDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Stand/Bin");
-        private static readonly string LaunchpadCache1 = Path.Combine(Environment.GetEnvironmentVariable("ProgramData") ?? string.Empty, "Calamity, Inc");
-        private static readonly string LaunchpadCache2 = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Calamity,_Inc");
+        private static readonly string StandCacheDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "Stand/Cache"
+        );
+        private static readonly string StandBinDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "Stand/Bin"
+        );
+        private static readonly string LaunchpadCache1 = Path.Combine(
+            Environment.GetEnvironmentVariable("ProgramData") ?? string.Empty,
+            "Calamity, Inc"
+        );
+        private static readonly string LaunchpadCache2 = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "Calamity,_Inc"
+        );
 
         public async Task ClearCache()
         {
@@ -24,15 +36,27 @@ namespace StandSupportTool
                 // Attempt to delete the Stand/Bin directory
                 resultMessage += $"Stand-Bin: {await DeleteDirectoryAsync(StandBinDir)}\n";
                 // Attempt to delete the first launchpad directory
-                resultMessage += $"Launchpad-Cache1: {await DeleteDirectoryAsync(LaunchpadCache1)}\n";
+                resultMessage +=
+                    $"Launchpad-Cache1: {await DeleteDirectoryAsync(LaunchpadCache1)}\n";
                 // Attempt to delete the second launchpad directory
-                resultMessage += $"Launchpad-Cache2: {await DeleteDirectoryAsync(LaunchpadCache2)}\n";
+                resultMessage +=
+                    $"Launchpad-Cache2: {await DeleteDirectoryAsync(LaunchpadCache2)}\n";
 
-                MessageBox.Show(resultMessage, "Result", MessageBoxButton.OK, MessageBoxImage.Information);
+                MessageBox.Show(
+                    resultMessage,
+                    "Result",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information
+                );
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Failed to delete specified directories: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Failed to delete specified directories: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
         }
 

--- a/src/StandSupportTool/ClearHotkeysManager.cs
+++ b/src/StandSupportTool/ClearHotkeysManager.cs
@@ -8,34 +8,69 @@ namespace StandSupportTool
     {
         public void ClearHotkeys()
         {
-            MessageBoxResult result = MessageBox.Show("This will delete your Hotkeys, do you want to continue?", "Confirmation", MessageBoxButton.YesNo, MessageBoxImage.Warning);
+            MessageBoxResult result = MessageBox.Show(
+                "This will delete your Hotkeys, do you want to continue?",
+                "Confirmation",
+                MessageBoxButton.YesNo,
+                MessageBoxImage.Warning
+            );
 
             if (result == MessageBoxResult.Yes)
             {
-                string hotkeysFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Stand/Hotkeys.txt");
+                string hotkeysFilePath = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                    "Stand/Hotkeys.txt"
+                );
 
-                if (Directory.Exists(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Stand")))
+                if (
+                    Directory.Exists(
+                        Path.Combine(
+                            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                            "Stand"
+                        )
+                    )
+                )
                 {
                     if (File.Exists(hotkeysFilePath))
                     {
                         try
                         {
                             File.Delete(hotkeysFilePath);
-                            MessageBox.Show("Hotkeys file has been deleted.", "Success", MessageBoxButton.OK, MessageBoxImage.Information);
+                            MessageBox.Show(
+                                "Hotkeys file has been deleted.",
+                                "Success",
+                                MessageBoxButton.OK,
+                                MessageBoxImage.Information
+                            );
                         }
                         catch (Exception ex)
                         {
-                            MessageBox.Show($"Failed to delete Hotkeys file: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                            MessageBox.Show(
+                                $"Failed to delete Hotkeys file: {ex.Message}",
+                                "Error",
+                                MessageBoxButton.OK,
+                                MessageBoxImage.Error
+                            );
                         }
                     }
                     else
                     {
-                        MessageBox.Show("Hotkeys file does not exist.", "Info", MessageBoxButton.OK, MessageBoxImage.Information);
+                        MessageBox.Show(
+                            "Hotkeys file does not exist.",
+                            "Info",
+                            MessageBoxButton.OK,
+                            MessageBoxImage.Information
+                        );
                     }
                 }
                 else
                 {
-                    MessageBoxResult dirResult = MessageBox.Show("You never used Stand on this PC. Are you sure you are right here?", "Warning", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    MessageBoxResult dirResult = MessageBox.Show(
+                        "You never used Stand on this PC. Are you sure you are right here?",
+                        "Warning",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Warning
+                    );
                     if (dirResult == MessageBoxResult.OK)
                     {
                         // Just close the dialog

--- a/src/StandSupportTool/CompatibilityScanner.cs
+++ b/src/StandSupportTool/CompatibilityScanner.cs
@@ -8,8 +8,17 @@ namespace StandSupportTool
     internal class CompatibilityScanner
     {
         private string gameExe = "GTA5.exe";
-        private string registryPath = Base64.Decode("U29mdHdhcmVcTWljcm9zb2Z0XFdpbmRvd3MgTlRcQ3VycmVudFZlcnNpb25cQXBwQ29tcGF0RmxhZ3NcTGF5ZXJz"); // @"Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers";
-        private string[] compatibilityFlags = { "WIN8RTM", "WIN7RTM", "VISTASP2", "VISTASP1", "VISTARTM" };
+        private string registryPath = Base64.Decode(
+            "U29mdHdhcmVcTWljcm9zb2Z0XFdpbmRvd3MgTlRcQ3VycmVudFZlcnNpb25cQXBwQ29tcGF0RmxhZ3NcTGF5ZXJz"
+        ); // @"Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers";
+        private string[] compatibilityFlags =
+        {
+            "WIN8RTM",
+            "WIN7RTM",
+            "VISTASP2",
+            "VISTASP1",
+            "VISTARTM",
+        };
 
         public bool IsGameRunningInCompatibilityMode()
         {
@@ -39,13 +48,23 @@ namespace StandSupportTool
                     }
                     else
                     {
-                        MessageBox.Show("Failed to open registry key to get compatibility mode.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                        MessageBox.Show(
+                            "Failed to open registry key to get compatibility mode.",
+                            "Error",
+                            MessageBoxButton.OK,
+                            MessageBoxImage.Error
+                        );
                     }
                 }
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"An error occurred while checking compatibility mode: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"An error occurred while checking compatibility mode: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
             // Seems like nothing has been flagged
             return false;

--- a/src/StandSupportTool/DashboardLinkOpener.cs
+++ b/src/StandSupportTool/DashboardLinkOpener.cs
@@ -13,11 +13,7 @@ namespace StandSupportTool
         {
             string url = "https://stand.sh/account/";
 
-            Process.Start(new ProcessStartInfo
-            {
-                FileName = url,
-                UseShellExecute = true
-            });
+            Process.Start(new ProcessStartInfo { FileName = url, UseShellExecute = true });
         }
     }
 }

--- a/src/StandSupportTool/Diagnostics.cs
+++ b/src/StandSupportTool/Diagnostics.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Management;
 using System.Net.Http;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -11,14 +13,14 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Xml.Linq;
-using System.Security.Cryptography;
-using System.Management;
 
 namespace StandSupportTool
 {
     internal class Diagnostics
     {
-        static string appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        static string appDataPath = Environment.GetFolderPath(
+            Environment.SpecialFolder.ApplicationData
+        );
         static string standDir = Path.Combine(appDataPath, "Stand");
 
         public class StandInjectionResult
@@ -33,6 +35,7 @@ namespace StandSupportTool
             public bool SHAValidationCheck { get; set; }
             public bool isUpToDate { get; set; }
         }
+
         public class StandMetaState
         {
             public string[] state { get; set; }
@@ -84,7 +87,14 @@ namespace StandSupportTool
                 if (File.Exists(logFilePath))
                 {
                     // Allows us to read the log even if the game is running with Stand injected.
-                    using (FileStream fs = new FileStream(logFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                    using (
+                        FileStream fs = new FileStream(
+                            logFilePath,
+                            FileMode.Open,
+                            FileAccess.Read,
+                            FileShare.ReadWrite
+                        )
+                    )
                     using (StreamReader sr = new StreamReader(fs))
                     {
                         var lines = new List<string>();
@@ -93,14 +103,21 @@ namespace StandSupportTool
                         {
                             if (line == null)
                             {
-                                MessageBox.Show("Encountered a null line in log file.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                                MessageBox.Show(
+                                    "Encountered a null line in log file.",
+                                    "Error",
+                                    MessageBoxButton.OK,
+                                    MessageBoxImage.Error
+                                );
                                 return result;
                             }
                             lines.Add(line);
                         }
 
                         // Find the index of the last line matching the regex
-                        int matchIndex = lines.FindLastIndex(line => line != null && Regex.IsMatch(line, standInjectionRegex));
+                        int matchIndex = lines.FindLastIndex(line =>
+                            line != null && Regex.IsMatch(line, standInjectionRegex)
+                        );
 
                         if (matchIndex != -1)
                         {
@@ -108,24 +125,42 @@ namespace StandSupportTool
                         }
                         else
                         {
-                            MessageBox.Show("No 'Stand' injection found in the log.", "Warning", MessageBoxButton.OK, MessageBoxImage.Warning);
+                            MessageBox.Show(
+                                "No 'Stand' injection found in the log.",
+                                "Warning",
+                                MessageBoxButton.OK,
+                                MessageBoxImage.Warning
+                            );
                         }
 
                         if (result.Log != null)
                         {
                             // Check for network issues within the log
-                            result.HasNetworkIssues = Regex.IsMatch(string.Join(Environment.NewLine, result.Log), networkErrorRegex);
+                            result.HasNetworkIssues = Regex.IsMatch(
+                                string.Join(Environment.NewLine, result.Log),
+                                networkErrorRegex
+                            );
                         }
                     }
                 }
                 else
                 {
-                    MessageBox.Show("Log file does not exist.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show(
+                        "Log file does not exist.",
+                        "Error",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Error
+                    );
                 }
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Failed to read log file, reason: {ex.Message}.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Failed to read log file, reason: {ex.Message}.",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
 
             return result;
@@ -148,15 +183,30 @@ namespace StandSupportTool
             }
             catch (FileNotFoundException)
             {
-                MessageBox.Show($"Stand.dll not found.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Stand.dll not found.",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
             catch (IOException ex)
             {
-                MessageBox.Show($"Error reading Stand.dll, reason:{ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Error reading Stand.dll, reason:{ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Error calculating SHA-256 hash for Stand.dll: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Error calculating SHA-256 hash for Stand.dll: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
 
             return "";
@@ -180,7 +230,12 @@ namespace StandSupportTool
 
                 if (dllFiles.Length == 0)
                 {
-                    MessageBox.Show($"Cannot find any Stand dll in: '{BinPath}'\nwhile checking if Stand DLL matches the upstream.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show(
+                        $"Cannot find any Stand dll in: '{BinPath}'\nwhile checking if Stand DLL matches the upstream.",
+                        "Error",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Error
+                    );
                     return false;
                 }
 
@@ -198,19 +253,32 @@ namespace StandSupportTool
                         string downloadedSHA256 = CalculateSHA256(dllBytes);
                         string installedSHA256 = GetInstalledDllSHA256();
 
-                        bool shaMatches = downloadedSHA256.Equals(installedSHA256, StringComparison.OrdinalIgnoreCase);
+                        bool shaMatches = downloadedSHA256.Equals(
+                            installedSHA256,
+                            StringComparison.OrdinalIgnoreCase
+                        );
                         return shaMatches;
                     }
                     else
                     {
-                        MessageBox.Show($"Failed to download DLL '{dllName}'. Status code: {response.StatusCode}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                        MessageBox.Show(
+                            $"Failed to download DLL '{dllName}'. Status code: {response.StatusCode}",
+                            "Error",
+                            MessageBoxButton.OK,
+                            MessageBoxImage.Error
+                        );
                         return false;
                     }
                 }
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Error downloading upstream DLL, reason: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Error downloading upstream DLL, reason: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
                 return false;
             }
         }
@@ -230,12 +298,22 @@ namespace StandSupportTool
             }
             catch (HttpRequestException ex)
             {
-                MessageBox.Show($"HTTP request error, reason: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"HTTP request error, reason: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
                 return false;
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Error connecting to stand.sh: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Error connecting to stand.sh: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
                 return false;
             }
         }
@@ -255,17 +333,29 @@ namespace StandSupportTool
                         string receivedVersions = await response.Content.ReadAsStringAsync();
 
                         int colonIndex = receivedVersions.IndexOf(':');
-                        return colonIndex != -1 ? new string(receivedVersions.Skip(colonIndex + 1).ToArray()).Trim() : string.Empty;
+                        return colonIndex != -1
+                            ? new string(receivedVersions.Skip(colonIndex + 1).ToArray()).Trim()
+                            : string.Empty;
                     }
                 }
             }
             catch (HttpRequestException ex)
             {
-                MessageBox.Show($"HTTP request error when trying to get upstream: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"HTTP request error when trying to get upstream: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Error connecting to stand.sh for upstream: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Error connecting to stand.sh for upstream: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
             return "";
         }
@@ -279,7 +369,12 @@ namespace StandSupportTool
 
             if (dllFiles.Length == 0)
             {
-                MessageBox.Show($"Cannot find any Stand dll in: '{BinPath}'\nwhile checking if Stand is up to date.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Cannot find any Stand dll in: '{BinPath}'\nwhile checking if Stand is up to date.",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
                 return false;
             }
 
@@ -314,11 +409,17 @@ namespace StandSupportTool
 
             if (!Directory.Exists(LuaPath))
             {
-                MessageBox.Show("Lua Script Directory doesn't exist", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    "Lua Script Directory doesn't exist",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
                 return new Dictionary<string, List<string>>();
             }
 
-            Dictionary<string, List<string>> directoryFiles = new Dictionary<string, List<string>>();
+            Dictionary<string, List<string>> directoryFiles =
+                new Dictionary<string, List<string>>();
             Stack<string> directories = new Stack<string>();
             directories.Push(LuaPath);
 
@@ -341,7 +442,9 @@ namespace StandSupportTool
                         directoryFiles[relativeDir].Add(Path.GetFileName(relativeFilePath));
                     }
 
-                    string[] subDirectories = await Task.Run(() => Directory.GetDirectories(currentPath));
+                    string[] subDirectories = await Task.Run(
+                        () => Directory.GetDirectories(currentPath)
+                    );
                     foreach (string directory in subDirectories)
                     {
                         directories.Push(directory);
@@ -350,23 +453,44 @@ namespace StandSupportTool
             }
             catch (UnauthorizedAccessException ex)
             {
-                MessageBox.Show($"Access denied: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Access denied: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
             catch (PathTooLongException ex)
             {
-                MessageBox.Show($"Path too long: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Path too long: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
             catch (IOException ex)
             {
-                MessageBox.Show($"IO error: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"IO error: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Unexpected error: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Unexpected error: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
 
             return directoryFiles;
         }
+
         static StandMetaState GetMetaState()
         {
             string metaStatePath = Path.Combine(standDir, "Meta State.txt");
@@ -403,12 +527,22 @@ namespace StandSupportTool
                 }
                 else
                 {
-                    MessageBox.Show("Meta State file does not exist.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show(
+                        "Meta State file does not exist.",
+                        "Error",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Error
+                    );
                 }
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Failed to read Meta State file, reason: {ex.Message}.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Failed to read Meta State file, reason: {ex.Message}.",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
 
             // Nothing was found in there, must be Default profile!
@@ -434,16 +568,27 @@ namespace StandSupportTool
                 }
                 else
                 {
-                    MessageBox.Show("Profile file does not exist", "Warning", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    MessageBox.Show(
+                        "Profile file does not exist",
+                        "Warning",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Warning
+                    );
                 }
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Failed to read Profile file, reason: {ex.Message}.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Failed to read Profile file, reason: {ex.Message}.",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
 
             return Array.Empty<string>();
         }
+
         static async Task<NetworkInfo> GetNetworkInfoAsync()
         {
             string url = "https://ipinfo.io/json";
@@ -468,40 +613,47 @@ namespace StandSupportTool
                             string asn = orgParts[0];
                             string provider = orgParts.Length > 1 ? orgParts[1] : string.Empty;
 
-                            return new NetworkInfo
-                            {
-                                ASN = asn,
-                                ISP = provider
-                            };
+                            return new NetworkInfo { ASN = asn, ISP = provider };
                         }
                     }
                 }
             }
             catch (HttpRequestException ex)
             {
-                MessageBox.Show($"HTTP request error: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"HTTP request error: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Error connecting to stand.sh: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Error connecting to stand.sh: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
 
             // Return empty info
             return new NetworkInfo();
         }
+
         static List<string> GetXMLValue(XElement settings, string settingName)
         {
-            var settingElement =
-                settings.Elements("setting")
-                        .FirstOrDefault(e =>
-                        {
-                            var attributeName = e.Attribute("name");
-                            if (attributeName != null)
-                            {
-                                return attributeName.Value == settingName;
-                            }
-                            return false;
-                        });
+            var settingElement = settings
+                .Elements("setting")
+                .FirstOrDefault(e =>
+                {
+                    var attributeName = e.Attribute("name");
+                    if (attributeName != null)
+                    {
+                        return attributeName.Value == settingName;
+                    }
+                    return false;
+                });
 
             if (settingElement != null)
             {
@@ -511,7 +663,10 @@ namespace StandSupportTool
                     if (valueElement != null)
                     {
                         string attributeValue = valueElement.Value;
-                        string[] paths = attributeValue.Split('|', StringSplitOptions.RemoveEmptyEntries);
+                        string[] paths = attributeValue.Split(
+                            '|',
+                            StringSplitOptions.RemoveEmptyEntries
+                        );
                         return paths.Select(path => Path.GetFileName(path.Trim())).ToList();
                     }
                 }
@@ -549,26 +704,35 @@ namespace StandSupportTool
             {
                 return new LaunchpadData
                 {
-                    GameLauncher = GetXMLValue(settings, "GameLauncher").FirstOrDefault() ?? "Unknown",
-                    CustomDlls = GetXMLValue(settings, "CustomDll").ToArray()
+                    GameLauncher =
+                        GetXMLValue(settings, "GameLauncher").FirstOrDefault() ?? "Unknown",
+                    CustomDlls = GetXMLValue(settings, "CustomDll").ToArray(),
                 };
             }
 
             // Return empty data
             return new LaunchpadData();
         }
+
         static LaunchpadData GetLaunchpadProfile()
         {
-            string localAppDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            string localAppDataPath = Environment.GetFolderPath(
+                Environment.SpecialFolder.LocalApplicationData
+            );
             string launchpadFolder = Path.Combine(localAppDataPath, "Calamity,_Inc");
 
             try
             {
                 if (Directory.Exists(launchpadFolder))
                 {
-                    var files = new DirectoryInfo(launchpadFolder).GetFiles("user.config", SearchOption.AllDirectories);
+                    var files = new DirectoryInfo(launchpadFolder).GetFiles(
+                        "user.config",
+                        SearchOption.AllDirectories
+                    );
 
-                    var lastModifiedFile = files.OrderByDescending(f => f.LastWriteTime).FirstOrDefault();
+                    var lastModifiedFile = files
+                        .OrderByDescending(f => f.LastWriteTime)
+                        .FirstOrDefault();
 
                     if (lastModifiedFile != null)
                     {
@@ -577,7 +741,12 @@ namespace StandSupportTool
                     }
                     else
                     {
-                        MessageBox.Show("No user.config file found for Stand Launchpad.", "Warning", MessageBoxButton.OK, MessageBoxImage.Warning);
+                        MessageBox.Show(
+                            "No user.config file found for Stand Launchpad.",
+                            "Warning",
+                            MessageBoxButton.OK,
+                            MessageBoxImage.Warning
+                        );
                     }
                 }
                 else
@@ -588,19 +757,27 @@ namespace StandSupportTool
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"An error occurred when trying to get Launchpad Data: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"An error occurred when trying to get Launchpad Data: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
 
             // Return empty data
             return new LaunchpadData();
         }
+
         static string GetOSName()
         {
             string osName = "Unknown";
 
             try
             {
-                using ManagementObjectSearcher searcher = new ManagementObjectSearcher("SELECT * FROM Win32_OperatingSystem");
+                using ManagementObjectSearcher searcher = new ManagementObjectSearcher(
+                    "SELECT * FROM Win32_OperatingSystem"
+                );
                 foreach (ManagementObject os in searcher.Get())
                 {
                     osName = os["Caption"]?.ToString() ?? "Unknown OS";
@@ -614,6 +791,7 @@ namespace StandSupportTool
 
             return osName;
         }
+
         public static async Task DiagnosticsAsync()
         {
             StandInjectionResult lastInjection = ParseLastStandInjection();
@@ -635,13 +813,14 @@ namespace StandSupportTool
                 {
                     IsAbleToConnect = isAbleToConnect,
                     SHAValidationCheck = shaValidationCheck,
-                    isUpToDate = await isStandUpToDate()
+                    isUpToDate = await isStandUpToDate(),
                 };
             }
 
             environmentData.networkInfo = await GetNetworkInfoAsync();
             environmentData.OS_VERSION = GetOSName();
-            environmentData.isRunningInCompatibilityMode = compatibilityScanner.IsGameRunningInCompatibilityMode();
+            environmentData.isRunningInCompatibilityMode =
+                compatibilityScanner.IsGameRunningInCompatibilityMode();
             environmentData.antivirusInfo = antivirusInfo.GetAntivirusInfo();
 
             StandDumpData data = new StandDumpData
@@ -653,13 +832,13 @@ namespace StandSupportTool
                 Checks = standChecks,
                 EnvironmentData = environmentData,
                 installedLuaScripts = await GetInstalledLuaScripts(),
-                LaunchpadData = GetLaunchpadProfile()
+                LaunchpadData = GetLaunchpadProfile(),
             };
 
-            string jsonData = JsonSerializer.Serialize(data, new JsonSerializerOptions
-            {
-                WriteIndented = true
-            });
+            string jsonData = JsonSerializer.Serialize(
+                data,
+                new JsonSerializerOptions { WriteIndented = true }
+            );
 
             string desktopPath = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
             string filePath = Path.Combine(desktopPath, $"stand_{data.ticketID}.json");
@@ -667,11 +846,21 @@ namespace StandSupportTool
             try
             {
                 await File.WriteAllTextAsync(filePath, jsonData);
-                MessageBox.Show($"A file named 'stand_{data.ticketID}.json' has been created on your Desktop.\nPlease send this file to the support chat for further assistance.", "Information", MessageBoxButton.OK, MessageBoxImage.Information);
+                MessageBox.Show(
+                    $"A file named 'stand_{data.ticketID}.json' has been created on your Desktop.\nPlease send this file to the support chat for further assistance.",
+                    "Information",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information
+                );
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Error writing output data to file: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Error writing output data to file: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
         }
     }

--- a/src/StandSupportTool/ExclusionManager.cs
+++ b/src/StandSupportTool/ExclusionManager.cs
@@ -14,7 +14,12 @@ namespace StandSupportTool
 
             if (!antivirusInfo.IsDefenderInstalled())
             {
-                MessageBox.Show("Seems like Defender is not installed in your system, this is not supported.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    "Seems like Defender is not installed in your system, this is not supported.",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
                 return;
             }
 
@@ -22,14 +27,17 @@ namespace StandSupportTool
                 "This feature will add an exclusion for Stand's BIN folder on Windows Defender.\n\nFor this, we need admin permissions.\n\nDo you want to continue?",
                 "Confirmation",
                 MessageBoxButton.YesNo,
-                MessageBoxImage.Question);
+                MessageBoxImage.Question
+            );
 
             if (result != MessageBoxResult.Yes)
             {
                 return;
             }
 
-            string appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            string appDataPath = Environment.GetFolderPath(
+                Environment.SpecialFolder.ApplicationData
+            );
             string exclusionPath = System.IO.Path.Combine(appDataPath, "Stand", "Bin");
 
             RestartAsAdmin($"--add-exclusion \"{exclusionPath}\"");
@@ -45,13 +53,13 @@ namespace StandSupportTool
         private static void RestartAsAdmin(string args = "")
         {
             string? exeName = Environment.ProcessPath;
-            if (exeName != null) 
+            if (exeName != null)
             {
                 var startInfo = new ProcessStartInfo(exeName)
                 {
                     UseShellExecute = true,
                     Verb = "runas",
-                    Arguments = args
+                    Arguments = args,
                 };
 
                 try
@@ -60,25 +68,41 @@ namespace StandSupportTool
                 }
                 catch (System.ComponentModel.Win32Exception)
                 {
-                    MessageBox.Show("This application requires administrator privileges to run. Please restart the application as an administrator.", "Administrator Privileges Required", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show(
+                        "This application requires administrator privileges to run. Please restart the application as an administrator.",
+                        "Administrator Privileges Required",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Error
+                    );
                 }
             }
-
         }
+
         public void AddExclusion(string exclusionPath)
         {
             try
             {
                 if (IsExclusionAdded(exclusionPath))
                 {
-                    MessageBox.Show("Exclusion already exists.", "Info", MessageBoxButton.OK, MessageBoxImage.Information);
+                    MessageBox.Show(
+                        "Exclusion already exists.",
+                        "Info",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Information
+                    );
                 }
                 else
                 {
-                    ManagementScope scope = new ManagementScope(@"\\.\root\Microsoft\Windows\Defender");
+                    ManagementScope scope = new ManagementScope(
+                        @"\\.\root\Microsoft\Windows\Defender"
+                    );
                     scope.Connect();
 
-                    ManagementClass instance = new ManagementClass(scope, new ManagementPath("MSFT_MpPreference"), null);
+                    ManagementClass instance = new ManagementClass(
+                        scope,
+                        new ManagementPath("MSFT_MpPreference"),
+                        null
+                    );
 
                     ManagementBaseObject inParams = instance.GetMethodParameters("Add");
                     inParams["ExclusionPath"] = new string[] { exclusionPath };
@@ -87,11 +111,21 @@ namespace StandSupportTool
 
                     if (IsExclusionAdded(exclusionPath))
                     {
-                        MessageBox.Show("Exclusion added.", "Success", MessageBoxButton.OK, MessageBoxImage.Information);
+                        MessageBox.Show(
+                            "Exclusion added.",
+                            "Success",
+                            MessageBoxButton.OK,
+                            MessageBoxImage.Information
+                        );
                     }
                     else
                     {
-                        MessageBox.Show("Failed to verify exclusion.", "Error", MessageBoxButton.OK, MessageBoxImage.Information);
+                        MessageBox.Show(
+                            "Failed to verify exclusion.",
+                            "Error",
+                            MessageBoxButton.OK,
+                            MessageBoxImage.Information
+                        );
                     }
 
                     Environment.Exit(0);
@@ -99,15 +133,30 @@ namespace StandSupportTool
             }
             catch (ManagementException mEx)
             {
-                MessageBox.Show($"WMI ManagementException: {mEx.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"WMI ManagementException: {mEx.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
             catch (UnauthorizedAccessException uEx)
             {
-                MessageBox.Show($"Unauthorized Access: {uEx.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Unauthorized Access: {uEx.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Unexpected error: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Unexpected error: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
 
             // We failed if we reach here
@@ -132,7 +181,13 @@ namespace StandSupportTool
                     {
                         foreach (string path in currentExclusions)
                         {
-                            if (string.Equals(path, exclusionPath, StringComparison.OrdinalIgnoreCase))
+                            if (
+                                string.Equals(
+                                    path,
+                                    exclusionPath,
+                                    StringComparison.OrdinalIgnoreCase
+                                )
+                            )
                             {
                                 return true;
                             }
@@ -142,7 +197,12 @@ namespace StandSupportTool
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Unexpected error when checking exclusion: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Unexpected error when checking exclusion: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
             return false;
         }

--- a/src/StandSupportTool/HotkeyManager.cs
+++ b/src/StandSupportTool/HotkeyManager.cs
@@ -24,7 +24,7 @@ namespace StandSupportTool
             new Hotkey { KeyBinding = "L", Action = "Right" },
             new Hotkey { KeyBinding = "Enter", Action = "Click" },
             new Hotkey { KeyBinding = "Backspace", Action = "Back" },
-            new Hotkey { KeyBinding = "O, Numpad 3, H", Action = "Context Menu" }
+            new Hotkey { KeyBinding = "O, Numpad 3, H", Action = "Context Menu" },
         };
 
         public ObservableCollection<Hotkey> Hotkeys
@@ -41,7 +41,9 @@ namespace StandSupportTool
 
         public HotkeyManager()
         {
-            string appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            string appDataPath = Environment.GetFolderPath(
+                Environment.SpecialFolder.ApplicationData
+            );
             string standDir = Path.Combine(appDataPath, "Stand");
             hotkeysFilePath = Path.Combine(standDir, "Hotkeys.txt");
 
@@ -58,7 +60,6 @@ namespace StandSupportTool
                 }
             }
         }
-
 
         public List<Hotkey> Parse()
         {
@@ -80,11 +81,7 @@ namespace StandSupportTool
                         string actionName = parts[0].Trim();
                         string keyBinding = parts[1].Trim();
 
-                        hotkeys.Add(new Hotkey
-                        {
-                            Action = actionName,
-                            KeyBinding = keyBinding
-                        });
+                        hotkeys.Add(new Hotkey { Action = actionName, KeyBinding = keyBinding });
                     }
                 }
             }
@@ -99,7 +96,12 @@ namespace StandSupportTool
             {
                 if (Hotkeys.Any(h => h.KeyBinding == hotkey.KeyBinding))
                 {
-                    MessageBox.Show($"The key '{hotkey.KeyBinding}' is already used. Please replace it.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show(
+                        $"The key '{hotkey.KeyBinding}' is already used. Please replace it.",
+                        "Error",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Error
+                    );
                 }
                 else
                 {
@@ -108,10 +110,11 @@ namespace StandSupportTool
             }
             writeSmallerKeyboardHotkeysOnSave = true;
         }
+
         private string ReplaceLineWithPreservedIndentation(string originalLine, string newLine)
         {
             int tabCount = originalLine.Length - originalLine.TrimStart('\t').Length;
-            return new string('\t', tabCount) + newLine; 
+            return new string('\t', tabCount) + newLine;
         }
 
         public void SaveHotkeys()
@@ -153,7 +156,9 @@ namespace StandSupportTool
             if (writeSmallerKeyboardHotkeysOnSave)
             {
                 // Find or create the "Keyboard Input Scheme" section
-                int inputSchemeIndex = lines.FindIndex(line => line.Trim() == "Keyboard Input Scheme");
+                int inputSchemeIndex = lines.FindIndex(line =>
+                    line.Trim() == "Keyboard Input Scheme"
+                );
                 if (inputSchemeIndex == -1)
                 {
                     // If "Keyboard Input Scheme" section is not found, add it at the end
@@ -172,7 +177,10 @@ namespace StandSupportTool
                 // Add or update hotkeys under the "Context Menu" subsection
                 foreach (var hotkey in Hotkeys60)
                 {
-                    int hotkeyIndex = lines.FindIndex(inputSchemeIndex, line => line.Trim().StartsWith(hotkey.Action + ":"));
+                    int hotkeyIndex = lines.FindIndex(
+                        inputSchemeIndex,
+                        line => line.Trim().StartsWith(hotkey.Action + ":")
+                    );
 
                     if (hotkeyIndex != -1)
                     {

--- a/src/StandSupportTool/LaunchpadManager.cs
+++ b/src/StandSupportTool/LaunchpadManager.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
 using System.Windows;
 
@@ -9,12 +10,12 @@ namespace StandSupportTool
 {
     public static class LaunchpadManager
     {
-        private const string ZipUrl =
-            "https://github.com/AXOca/StandSupportTool/raw/main/launchpad/launchpad.zip";
+        private const string LaunchPadUrl =
+            "https://api.github.com/repos/calamity-inc/Stand-Launchpad/releases/latest";
         private const string ConfirmationMessage =
-            "This feature will download Stand's Launchpad into a new folder on your desktop and exclude it automatically from Windows Defender.\n\nFor this, we need admin permissions.\n\nDo you want to continue?";
+            "This feature will download Stand's Launchpad on your desktop and exclude it automatically from Windows Defender.\n\nFor this, we need admin permissions.\n\nDo you want to continue?";
         private const string SuccessMessage =
-            "Done.\n\nLook at your Desktop, go into the \"Stand_Launchpad\" folder and unpack it.\n\nThe password is: stand.sh";
+            "Done!\nYou should have the Launchpad on the Desktop.";
         private const string ErrorMessage =
             "Operation cancelled or failed due to insufficient permissions.";
 
@@ -25,11 +26,13 @@ namespace StandSupportTool
                 return;
             }
 
-            string folderPath = CreateDesktopFolder("Stand_Launchpad");
+            string launchpadPath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.Desktop),
+                "StandLaunchpad.exe"
+            );
+            AddExclusion(launchpadPath);
 
-            AddExclusion(folderPath);
-
-            await DownloadLaunchpadAsync(folderPath);
+            await DownloadLatestExeAsync(launchpadPath);
 
             InformUserOfSuccess();
         }
@@ -44,14 +47,6 @@ namespace StandSupportTool
             );
 
             return result == MessageBoxResult.Yes;
-        }
-
-        private static string CreateDesktopFolder(string folderName)
-        {
-            string desktopPath = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
-            string folderPath = Path.Combine(desktopPath, folderName);
-            Directory.CreateDirectory(folderPath);
-            return folderPath;
         }
 
         private static void AddExclusion(string folderPath)
@@ -86,10 +81,51 @@ namespace StandSupportTool
             }
         }
 
-        private static async Task DownloadLaunchpadAsync(string folderPath)
+        private static async Task DownloadLatestExeAsync(string destinationPath)
         {
-            string zipPath = Path.Combine(folderPath, "launchpad.zip");
-            await DownloadFileAsync(ZipUrl, zipPath);
+            using (HttpClient client = new HttpClient())
+            {
+                client.DefaultRequestHeaders.Add("User-Agent", "C# App");
+
+                var response = await client.GetAsync(LaunchPadUrl);
+                if (response.IsSuccessStatusCode)
+                {
+                    var jsonResponse = await response.Content.ReadAsStringAsync();
+                    using (JsonDocument doc = JsonDocument.Parse(jsonResponse))
+                    {
+                        JsonElement root = doc.RootElement;
+                        JsonElement assets = root.GetProperty("assets");
+
+                        foreach (JsonElement asset in assets.EnumerateArray())
+                        {
+                            string name = asset.GetProperty("name").GetString();
+                            if (name.EndsWith(".exe"))
+                            {
+                                string downloadUrl = asset
+                                    .GetProperty("browser_download_url")
+                                    .GetString();
+                                await DownloadFileAsync(downloadUrl, destinationPath);
+                                return;
+                            }
+                        }
+                    }
+                    MessageBox.Show(
+                        "No .exe file found in the latest release.",
+                        "Error",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Error
+                    );
+                }
+                else
+                {
+                    MessageBox.Show(
+                        $"Failed to retrieve the latest release. Status code: {response.StatusCode}",
+                        "Error",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Error
+                    );
+                }
+            }
         }
 
         private static async Task DownloadFileAsync(string url, string destinationPath)

--- a/src/StandSupportTool/LaunchpadManager.cs
+++ b/src/StandSupportTool/LaunchpadManager.cs
@@ -9,10 +9,14 @@ namespace StandSupportTool
 {
     public static class LaunchpadManager
     {
-        private const string ZipUrl = "https://github.com/AXOca/StandSupportTool/raw/main/launchpad/launchpad.zip";
-        private const string ConfirmationMessage = "This feature will download Stand's Launchpad into a new folder on your desktop and exclude it automatically from Windows Defender.\n\nFor this, we need admin permissions.\n\nDo you want to continue?";
-        private const string SuccessMessage = "Done.\n\nLook at your Desktop, go into the \"Stand_Launchpad\" folder and unpack it.\n\nThe password is: stand.sh";
-        private const string ErrorMessage = "Operation cancelled or failed due to insufficient permissions.";
+        private const string ZipUrl =
+            "https://github.com/AXOca/StandSupportTool/raw/main/launchpad/launchpad.zip";
+        private const string ConfirmationMessage =
+            "This feature will download Stand's Launchpad into a new folder on your desktop and exclude it automatically from Windows Defender.\n\nFor this, we need admin permissions.\n\nDo you want to continue?";
+        private const string SuccessMessage =
+            "Done.\n\nLook at your Desktop, go into the \"Stand_Launchpad\" folder and unpack it.\n\nThe password is: stand.sh";
+        private const string ErrorMessage =
+            "Operation cancelled or failed due to insufficient permissions.";
 
         public static async Task PerformTest()
         {
@@ -36,7 +40,8 @@ namespace StandSupportTool
                 ConfirmationMessage,
                 "Confirmation",
                 MessageBoxButton.YesNo,
-                MessageBoxImage.Question);
+                MessageBoxImage.Question
+            );
 
             return result == MessageBoxResult.Yes;
         }
@@ -64,7 +69,7 @@ namespace StandSupportTool
                 Arguments = cmdArguments,
                 Verb = "runas",
                 UseShellExecute = true,
-                CreateNoWindow = true
+                CreateNoWindow = true,
             };
 
             try
@@ -93,7 +98,14 @@ namespace StandSupportTool
             {
                 var response = await client.GetAsync(url);
                 response.EnsureSuccessStatusCode();
-                await using (var fs = new FileStream(destinationPath, FileMode.Create, FileAccess.Write, FileShare.None))
+                await using (
+                    var fs = new FileStream(
+                        destinationPath,
+                        FileMode.Create,
+                        FileAccess.Write,
+                        FileShare.None
+                    )
+                )
                 {
                     await response.Content.CopyToAsync(fs);
                 }
@@ -102,7 +114,12 @@ namespace StandSupportTool
 
         private static void InformUserOfSuccess()
         {
-            MessageBox.Show(SuccessMessage, "Success", MessageBoxButton.OK, MessageBoxImage.Information);
+            MessageBox.Show(
+                SuccessMessage,
+                "Success",
+                MessageBoxButton.OK,
+                MessageBoxImage.Information
+            );
         }
     }
 }

--- a/src/StandSupportTool/LogManager.cs
+++ b/src/StandSupportTool/LogManager.cs
@@ -11,7 +11,11 @@ namespace StandSupportTool
         public LogManager()
         {
             // Initialize the path to the log file
-            logFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Stand", "Log.txt");
+            logFilePath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "Stand",
+                "Log.txt"
+            );
         }
 
         // Display a window for the user to select log entries and copy to clipboard

--- a/src/StandSupportTool/MainWindow.xaml.cs
+++ b/src/StandSupportTool/MainWindow.xaml.cs
@@ -1,11 +1,11 @@
 ﻿using System;
+using System.Diagnostics;
+using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Interop;
-using System.Diagnostics;
-using System.Threading.Tasks;
-using System.Reflection;
 
 namespace StandSupportTool
 {
@@ -40,13 +40,23 @@ namespace StandSupportTool
             var window = new WindowInteropHelper(this).Handle;
             var attr = DWMWINDOWATTRIBUTE.DWMWA_USE_IMMERSIVE_DARK_MODE;
             var useImmersiveDarkMode = true;
-            DwmSetWindowAttribute(window, attr, ref useImmersiveDarkMode, Marshal.SizeOf(typeof(bool)));
+            DwmSetWindowAttribute(
+                window,
+                attr,
+                ref useImmersiveDarkMode,
+                Marshal.SizeOf(typeof(bool))
+            );
         }
 
         private const int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
 
         [DllImport("dwmapi.dll", CharSet = CharSet.Unicode, PreserveSig = true)]
-        private static extern int DwmSetWindowAttribute(IntPtr hwnd, DWMWINDOWATTRIBUTE attribute, ref bool pvAttribute, int cbAttribute);
+        private static extern int DwmSetWindowAttribute(
+            IntPtr hwnd,
+            DWMWINDOWATTRIBUTE attribute,
+            ref bool pvAttribute,
+            int cbAttribute
+        );
 
         public enum DWMWINDOWATTRIBUTE
         {
@@ -75,6 +85,7 @@ namespace StandSupportTool
                 }
             }
         }
+
         private string GetVersion()
         {
             var version = Assembly.GetExecutingAssembly().GetName().Version;
@@ -141,7 +152,8 @@ namespace StandSupportTool
             }
         }
 
-        private void CopyLogToClipboard_Click(object sender, RoutedEventArgs e) => logManager.CopyLogToClipboard();
+        private void CopyLogToClipboard_Click(object sender, RoutedEventArgs e) =>
+            logManager.CopyLogToClipboard();
 
         private void CopyProfileToClipboard_Click(object sender, RoutedEventArgs e)
         {
@@ -152,7 +164,9 @@ namespace StandSupportTool
         {
             activationManager.SetActivationKey(this);
             // Updates the key back when the user saved it
-            ActivationKeyText.Text = activationManager.ReadActivationKey().Replace("Stand-Activate-", "");
+            ActivationKeyText.Text = activationManager
+                .ReadActivationKey()
+                .Replace("Stand-Activate-", "");
         }
 
         private void HotkeyButton_Click(object sender, RoutedEventArgs e)
@@ -162,20 +176,24 @@ namespace StandSupportTool
             hotkeysTable.ShowDialog();
         }
 
-        private void OpenYouTubeLink_Click(object sender, RoutedEventArgs e) => YouTubeLinkOpener.OpenYouTubeLink();
+        private void OpenYouTubeLink_Click(object sender, RoutedEventArgs e) =>
+            YouTubeLinkOpener.OpenYouTubeLink();
 
-        private void AddStandToExclusionsV2_Click(object sender, RoutedEventArgs e) => ExclusionManager.AddDefenderExclusion();
+        private void AddStandToExclusionsV2_Click(object sender, RoutedEventArgs e) =>
+            ExclusionManager.AddDefenderExclusion();
 
         private async void Launchpad_Click(object sender, RoutedEventArgs e)
         {
             AntivirusInfo avInfo = new AntivirusInfo();
 
-            if (avInfo.Is3rdPartyInstalled()) 
+            if (avInfo.Is3rdPartyInstalled())
             {
-                MessageBox.Show("Third-party antivirus software detected\nThis could cause issues when downloading the Launchpad.",
-                "3rd Party Antivirus Detected",
-                MessageBoxButton.OK,
-                MessageBoxImage.Warning);
+                MessageBox.Show(
+                    "Third-party antivirus software detected\nThis could cause issues when downloading the Launchpad.",
+                    "3rd Party Antivirus Detected",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Warning
+                );
             }
 
             await LaunchpadManager.PerformTest();
@@ -196,7 +214,12 @@ namespace StandSupportTool
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"An error occurred while trying to run Diagnostics: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"An error occurred while trying to run Diagnostics: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
         }
     }

--- a/src/StandSupportTool/ProfileManager.cs
+++ b/src/StandSupportTool/ProfileManager.cs
@@ -12,7 +12,9 @@ namespace StandSupportTool
         public ProfileManager()
         {
             // Initialize paths
-            string appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            string appDataPath = Environment.GetFolderPath(
+                Environment.SpecialFolder.ApplicationData
+            );
             string standDir = Path.Combine(appDataPath, "Stand");
             metaStateFilePath = Path.Combine(standDir, "Meta State.txt");
             profilesDirectoryPath = Path.Combine(standDir, "Profiles");
@@ -35,12 +37,22 @@ namespace StandSupportTool
                     }
                 }
 
-                MessageBox.Show("Active profile not found.", "Info", MessageBoxButton.OK, MessageBoxImage.Information);
+                MessageBox.Show(
+                    "Active profile not found.",
+                    "Info",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information
+                );
                 return string.Empty;
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Failed to get active profile: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Failed to get active profile: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
                 return string.Empty;
             }
         }
@@ -58,13 +70,23 @@ namespace StandSupportTool
                 }
                 else
                 {
-                    MessageBox.Show($"Profile {profileName} not found.", "Info", MessageBoxButton.OK, MessageBoxImage.Information);
+                    MessageBox.Show(
+                        $"Profile {profileName} not found.",
+                        "Info",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Information
+                    );
                     return string.Empty;
                 }
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Failed to read profile: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Failed to read profile: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
                 return string.Empty;
             }
         }
@@ -78,12 +100,22 @@ namespace StandSupportTool
                 if (!string.IsNullOrEmpty(profileContent))
                 {
                     Clipboard.SetText(profileContent);
-                    MessageBox.Show($"Profile {profileName} copied to clipboard.", "Success", MessageBoxButton.OK, MessageBoxImage.Information);
+                    MessageBox.Show(
+                        $"Profile {profileName} copied to clipboard.",
+                        "Success",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Information
+                    );
                 }
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Failed to copy profile to clipboard: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Failed to copy profile to clipboard: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
         }
     }

--- a/src/StandSupportTool/ProtocolManager.cs
+++ b/src/StandSupportTool/ProtocolManager.cs
@@ -20,7 +20,10 @@ namespace StandSupportTool
         {
             try
             {
-                string standDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Stand");
+                string standDir = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                    "Stand"
+                );
                 string stateFile = Path.Combine(standDir, "Meta State.txt");
 
                 if (File.Exists(stateFile))
@@ -41,7 +44,12 @@ namespace StandSupportTool
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Failed to read protocol: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Failed to read protocol: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
                 choosenProtocol = "SMART"; // Fallback to default in case of an error
             }
         }
@@ -69,7 +77,12 @@ namespace StandSupportTool
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Failed to focus unload: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Failed to focus unload: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
         }
 
@@ -78,12 +91,20 @@ namespace StandSupportTool
         {
             try
             {
-                string standDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Stand");
+                string standDir = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                    "Stand"
+                );
                 string stateFile = Path.Combine(standDir, "Meta State.txt");
 
                 if (!Directory.Exists(standDir))
                 {
-                    MessageBox.Show("Stand folder doesn't exist, make sure to run Stand before changing protocol!", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show(
+                        "Stand folder doesn't exist, make sure to run Stand before changing protocol!",
+                        "Error",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Error
+                    );
                     return;
                 }
 
@@ -114,14 +135,24 @@ namespace StandSupportTool
                     }
                 }
 
-                MessageBox.Show("Protocol changed successfully.\nMake sure to Unload and reinject Stand!", "Success", MessageBoxButton.OK, MessageBoxImage.Information);
+                MessageBox.Show(
+                    "Protocol changed successfully.\nMake sure to Unload and reinject Stand!",
+                    "Success",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information
+                );
 
                 // Focuses Unload on Stand (Hopefully the user will press that damn button!)
                 focusUnload();
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Failed to write protocol: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Failed to write protocol: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
         }
     }

--- a/src/StandSupportTool/ResetManager.cs
+++ b/src/StandSupportTool/ResetManager.cs
@@ -10,9 +10,19 @@ namespace StandSupportTool
     internal class ResetManager
     {
         // Show a confirmation dialog and return true if the user clicks 'Yes'
-        private bool ShowConfirmation(string message, string caption, MessageBoxImage icon = MessageBoxImage.Question)
+        private bool ShowConfirmation(
+            string message,
+            string caption,
+            MessageBoxImage icon = MessageBoxImage.Question
+        )
         {
-            MessageBoxResult result = MessageBox.Show(message, caption, MessageBoxButton.YesNo, icon, MessageBoxResult.No);
+            MessageBoxResult result = MessageBox.Show(
+                message,
+                caption,
+                MessageBoxButton.YesNo,
+                icon,
+                MessageBoxResult.No
+            );
             return result == MessageBoxResult.Yes;
         }
 
@@ -20,11 +30,22 @@ namespace StandSupportTool
         public void FullReset()
         {
             // Initial prompt
-            if (!ShowConfirmation("Please close GTA V and Stand's Launchpad. Continue?", "Initial Prompt"))
+            if (
+                !ShowConfirmation(
+                    "Please close GTA V and Stand's Launchpad. Continue?",
+                    "Initial Prompt"
+                )
+            )
                 return;
 
             // Confirmation dialog
-            if (!ShowConfirmation("Are you sure you want to do that? All your outfits and individual settings will be lost.", "Confirmation Dialog", MessageBoxImage.Warning))
+            if (
+                !ShowConfirmation(
+                    "Are you sure you want to do that? All your outfits and individual settings will be lost.",
+                    "Confirmation Dialog",
+                    MessageBoxImage.Warning
+                )
+            )
                 return;
 
             // Backup choice
@@ -44,7 +65,10 @@ namespace StandSupportTool
         {
             try
             {
-                string standDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Stand");
+                string standDir = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                    "Stand"
+                );
                 var itemsToBackup = SelectItemsToBackup(standDir);
 
                 if (itemsToBackup == null || !itemsToBackup.Any())
@@ -70,12 +94,22 @@ namespace StandSupportTool
                     }
                 }
 
-                MessageBox.Show("Backup completed successfully.", "Success", MessageBoxButton.OK, MessageBoxImage.Information);
+                MessageBox.Show(
+                    "Backup completed successfully.",
+                    "Success",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information
+                );
                 return true;
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Failed to backup Stand data: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Failed to backup Stand data: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
                 return false;
             }
         }
@@ -107,7 +141,7 @@ namespace StandSupportTool
                 Width = 400,
                 Height = 400,
                 WindowStartupLocation = WindowStartupLocation.CenterScreen,
-                ResizeMode = ResizeMode.CanResize
+                ResizeMode = ResizeMode.CanResize,
             };
 
             var grid = new Grid();
@@ -125,12 +159,20 @@ namespace StandSupportTool
             var listBox = new ListBox
             {
                 SelectionMode = SelectionMode.Multiple,
-                Margin = new Thickness(10)
+                Margin = new Thickness(10),
             };
             scrollViewer.Content = listBox;
 
-            var folders = Directory.GetDirectories(standDir).Select(Path.GetFileName).OrderBy(f => f).ToArray();
-            var files = Directory.GetFiles(standDir).Select(Path.GetFileName).OrderBy(f => f).ToArray();
+            var folders = Directory
+                .GetDirectories(standDir)
+                .Select(Path.GetFileName)
+                .OrderBy(f => f)
+                .ToArray();
+            var files = Directory
+                .GetFiles(standDir)
+                .Select(Path.GetFileName)
+                .OrderBy(f => f)
+                .ToArray();
 
             foreach (var folder in folders)
             {
@@ -146,7 +188,7 @@ namespace StandSupportTool
             {
                 Orientation = Orientation.Horizontal,
                 HorizontalAlignment = HorizontalAlignment.Center,
-                Margin = new Thickness(10)
+                Margin = new Thickness(10),
             };
             Grid.SetRow(buttonPanel, 1);
             grid.Children.Add(buttonPanel);
@@ -155,7 +197,7 @@ namespace StandSupportTool
             {
                 Content = "OK",
                 Width = 75,
-                Margin = new Thickness(5)
+                Margin = new Thickness(5),
             };
             okButton.Click += (sender, e) => dialog.DialogResult = true;
             buttonPanel.Children.Add(okButton);
@@ -164,7 +206,7 @@ namespace StandSupportTool
             {
                 Content = "Cancel",
                 Width = 75,
-                Margin = new Thickness(5)
+                Margin = new Thickness(5),
             };
             cancelButton.Click += (sender, e) => dialog.DialogResult = false;
             buttonPanel.Children.Add(cancelButton);
@@ -173,7 +215,7 @@ namespace StandSupportTool
             {
                 Content = "Backup All",
                 Width = 75,
-                Margin = new Thickness(5)
+                Margin = new Thickness(5),
             };
             backupAllButton.Click += (sender, e) =>
             {
@@ -186,8 +228,8 @@ namespace StandSupportTool
 
             if (dialog.DialogResult == true)
             {
-                return listBox.SelectedItems
-                    .Cast<string>()
+                return listBox
+                    .SelectedItems.Cast<string>()
                     .Select(item => item.Split(' ', 2)[1])
                     .ToArray();
             }
@@ -199,21 +241,39 @@ namespace StandSupportTool
         {
             try
             {
-                string standDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Stand");
+                string standDir = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                    "Stand"
+                );
 
                 if (Directory.Exists(standDir))
                 {
                     Directory.Delete(standDir, true);
-                    MessageBox.Show("All Stand data has been deleted.", "Success", MessageBoxButton.OK, MessageBoxImage.Information);
+                    MessageBox.Show(
+                        "All Stand data has been deleted.",
+                        "Success",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Information
+                    );
                 }
                 else
                 {
-                    MessageBox.Show("Stand directory does not exist.", "Info", MessageBoxButton.OK, MessageBoxImage.Information);
+                    MessageBox.Show(
+                        "Stand directory does not exist.",
+                        "Info",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Information
+                    );
                 }
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Failed to delete Stand data: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Failed to delete Stand data: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
         }
     }

--- a/src/StandSupportTool/SelectLogWindow.xaml.cs
+++ b/src/StandSupportTool/SelectLogWindow.xaml.cs
@@ -12,7 +12,8 @@ namespace StandSupportTool
     public partial class SelectLogWindow : BaseWindow
     {
         private readonly string logFilePath;
-        private readonly string standInjectionRegex = @"^.*Stand\s\d+(\.\d+)?\sreporting\sfor\sduty!$";
+        private readonly string standInjectionRegex =
+            @"^.*Stand\s\d+(\.\d+)?\sreporting\sfor\sduty!$";
         private List<string> allLogLines;
 
         public SelectLogWindow(string logFilePath)
@@ -31,7 +32,14 @@ namespace StandSupportTool
             {
                 if (File.Exists(logFilePath))
                 {
-                    using (FileStream fs = new FileStream(logFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                    using (
+                        FileStream fs = new FileStream(
+                            logFilePath,
+                            FileMode.Open,
+                            FileAccess.Read,
+                            FileShare.ReadWrite
+                        )
+                    )
                     using (StreamReader sr = new StreamReader(fs))
                     {
                         string? line;
@@ -54,12 +62,22 @@ namespace StandSupportTool
                 }
                 else
                 {
-                    MessageBox.Show("Log file not found.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show(
+                        "Log file not found.",
+                        "Error",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Error
+                    );
                 }
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Failed to read log file: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Failed to read log file: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
             }
         }
 
@@ -70,11 +88,17 @@ namespace StandSupportTool
                     log,
                     System.Globalization.CultureInfo.CurrentCulture,
                     FlowDirection.LeftToRight,
-                    new Typeface(LogListBox.FontFamily, LogListBox.FontStyle, LogListBox.FontWeight, LogListBox.FontStretch),
+                    new Typeface(
+                        LogListBox.FontFamily,
+                        LogListBox.FontStyle,
+                        LogListBox.FontWeight,
+                        LogListBox.FontStretch
+                    ),
                     LogListBox.FontSize,
                     Brushes.White,
                     new NumberSubstitution(),
-                    1))
+                    1
+                ))
                 .ToList();
 
             // Gives padding on the side to fix the content
@@ -89,19 +113,36 @@ namespace StandSupportTool
             {
                 string logContent = GetLogEntriesAfterSelected(selectedEntry);
                 Clipboard.SetText(logContent);
-                MessageBox.Show("Selected log entries copied to clipboard.", "Success", MessageBoxButton.OK, MessageBoxImage.Information);
+                MessageBox.Show(
+                    "Selected log entries copied to clipboard.",
+                    "Success",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information
+                );
             }
             else
             {
-                var mostRecentEntry = MostRecentLogListBox.ItemsSource.Cast<string>().FirstOrDefault();
+                var mostRecentEntry = MostRecentLogListBox
+                    .ItemsSource.Cast<string>()
+                    .FirstOrDefault();
                 if (mostRecentEntry != null)
                 {
                     Clipboard.SetText(GetLogEntriesAfterSelected(mostRecentEntry));
-                    MessageBox.Show("Most recent log entry copied to clipboard.", "Success", MessageBoxButton.OK, MessageBoxImage.Information);
+                    MessageBox.Show(
+                        "Most recent log entry copied to clipboard.",
+                        "Success",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Information
+                    );
                 }
                 else
                 {
-                    MessageBox.Show("No entry selected.", "Warning", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    MessageBox.Show(
+                        "No entry selected.",
+                        "Warning",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Warning
+                    );
                 }
             }
         }

--- a/src/StandSupportTool/UpdateManager.cs
+++ b/src/StandSupportTool/UpdateManager.cs
@@ -2,9 +2,9 @@
 using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
 using System.Windows;
-using System.Text.Json;
 
 namespace StandSupportTool
 {
@@ -12,7 +12,8 @@ namespace StandSupportTool
     {
         private const string RepoOwner = "AXOca";
         private const string RepoName = "StandSupportTool";
-        private const string ApiUrl = $"https://api.github.com/repos/{RepoOwner}/{RepoName}/releases/latest";
+        private const string ApiUrl =
+            $"https://api.github.com/repos/{RepoOwner}/{RepoName}/releases/latest";
         private readonly string currentVersion;
         private readonly string executablePath;
 
@@ -21,30 +22,46 @@ namespace StandSupportTool
             this.currentVersion = currentVersion;
             this.executablePath = executablePath;
         }
+
         public async Task<bool> CheckForUpdates()
         {
             try
             {
                 using (HttpClient client = new HttpClient())
                 {
-                    client.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0 (compatible; StandSupportToolClient/1.0)");
+                    client.DefaultRequestHeaders.UserAgent.ParseAdd(
+                        "Mozilla/5.0 (compatible; StandSupportToolClient/1.0)"
+                    );
                     string json = await client.GetStringAsync(ApiUrl);
                     using JsonDocument doc = JsonDocument.Parse(json);
                     JsonElement root = doc.RootElement;
-                    if (root.TryGetProperty("tag_name", out JsonElement tagNameElement) && tagNameElement.GetString() is string latestVersion)
+                    if (
+                        root.TryGetProperty("tag_name", out JsonElement tagNameElement)
+                        && tagNameElement.GetString() is string latestVersion
+                    )
                     {
                         return CompareVersions(latestVersion.Trim(), currentVersion);
                     }
                     else
                     {
-                        MessageBox.Show("Failed to retrieve the latest version.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                        MessageBox.Show(
+                            "Failed to retrieve the latest version.",
+                            "Error",
+                            MessageBoxButton.OK,
+                            MessageBoxImage.Error
+                        );
                         return false;
                     }
                 }
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Failed to check for updates: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Failed to check for updates: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
                 return false;
             }
         }
@@ -55,20 +72,34 @@ namespace StandSupportTool
             {
                 using (HttpClient client = new HttpClient())
                 {
-                    client.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0 (compatible; StandSupportToolClient/1.0)");
+                    client.DefaultRequestHeaders.UserAgent.ParseAdd(
+                        "Mozilla/5.0 (compatible; StandSupportToolClient/1.0)"
+                    );
                     string json = await client.GetStringAsync(ApiUrl);
                     using JsonDocument doc = JsonDocument.Parse(json);
                     JsonElement root = doc.RootElement;
-                    if (root.TryGetProperty("assets", out JsonElement assetsElement) && assetsElement[0].TryGetProperty("browser_download_url", out JsonElement downloadUrlElement) && downloadUrlElement.GetString() is string downloadUrl)
+                    if (
+                        root.TryGetProperty("assets", out JsonElement assetsElement)
+                        && assetsElement[0]
+                            .TryGetProperty(
+                                "browser_download_url",
+                                out JsonElement downloadUrlElement
+                            )
+                        && downloadUrlElement.GetString() is string downloadUrl
+                    )
                     {
                         byte[] data = await client.GetByteArrayAsync(downloadUrl);
-                        string tempFilePath = Path.Combine(Path.GetTempPath(), "StandSupportTool_new.exe");
+                        string tempFilePath = Path.Combine(
+                            Path.GetTempPath(),
+                            "StandSupportTool_new.exe"
+                        );
 
                         File.WriteAllBytes(tempFilePath, data);
 
                         string batchFilePath = Path.Combine(Path.GetTempPath(), "update.bat");
 
-                        string batchScript = $@"
+                        string batchScript =
+                            $@"
                             @echo off
                             taskkill /f /im {Path.GetFileName(executablePath)} > nul 2>&1
                             timeout /t 2 /nobreak > nul
@@ -90,15 +121,23 @@ namespace StandSupportTool
 
                         File.WriteAllText(batchFilePath, batchScript);
 
-                        ProcessStartInfo processStartInfo = new ProcessStartInfo("cmd.exe", $"/c \"{batchFilePath}\"")
+                        ProcessStartInfo processStartInfo = new ProcessStartInfo(
+                            "cmd.exe",
+                            $"/c \"{batchFilePath}\""
+                        )
                         {
                             CreateNoWindow = true,
-                            UseShellExecute = false
+                            UseShellExecute = false,
                         };
 
                         Process.Start(processStartInfo);
 
-                        MessageBox.Show($"Update downloaded to: {tempFilePath}", "Update Info", MessageBoxButton.OK, MessageBoxImage.Information);
+                        MessageBox.Show(
+                            $"Update downloaded to: {tempFilePath}",
+                            "Update Info",
+                            MessageBoxButton.OK,
+                            MessageBoxImage.Information
+                        );
 
                         LogUpdateProcess(tempFilePath, "Update process initiated.");
 
@@ -106,13 +145,23 @@ namespace StandSupportTool
                     }
                     else
                     {
-                        MessageBox.Show("Failed to retrieve the download URL.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                        MessageBox.Show(
+                            "Failed to retrieve the download URL.",
+                            "Error",
+                            MessageBoxButton.OK,
+                            MessageBoxImage.Error
+                        );
                     }
                 }
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"Failed to download update: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(
+                    $"Failed to download update: {ex.Message}",
+                    "Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error
+                );
                 LogUpdateProcess(null, $"Error - {ex.Message}");
             }
         }
@@ -132,7 +181,10 @@ namespace StandSupportTool
                 logMessage += $" Temp file path: {tempFilePath}";
             }
 
-            File.AppendAllText(Path.Combine(Path.GetTempPath(), "update_log.txt"), logMessage + Environment.NewLine);
+            File.AppendAllText(
+                Path.Combine(Path.GetTempPath(), "update_log.txt"),
+                logMessage + Environment.NewLine
+            );
         }
     }
 }

--- a/src/StandSupportTool/YouTubeLinkOpener.cs
+++ b/src/StandSupportTool/YouTubeLinkOpener.cs
@@ -11,11 +11,7 @@ namespace StandSupportTool
             string url = "https://www.youtube.com/watch?v=UbtuQwgNfp0";
 
             // Start the process to open the YouTube link in the default web browser
-            Process.Start(new ProcessStartInfo
-            {
-                FileName = url,
-                UseShellExecute = true
-            });
+            Process.Start(new ProcessStartInfo { FileName = url, UseShellExecute = true });
         }
     }
 }

--- a/src/StandSupportTool/themes/Dark.xaml.cs
+++ b/src/StandSupportTool/themes/Dark.xaml.cs
@@ -17,7 +17,5 @@ namespace StandSupportTool.themes
     /// <summary>
     /// Interaction logic for Dark.xaml
     /// </summary>
-    public partial class Dark : Window
-    {
-    }
+    public partial class Dark : Window { }
 }


### PR DESCRIPTION
I have changed the way Stand Launchpad is downloaded, now instead of downloading a .zip we use the free [GitHub API](https://docs.github.com/en/rest?apiVersion=2022-11-28) to always download the latest version of the Launchpad ([from its official repo](https://github.com/calamity-inc/Stand-Launchpad)), and we don't download it in a folder, we directly add it to the user's desktop but not before having added that .exe to the Windows Defender exclusions 😄.